### PR TITLE
Have fewer static tasks

### DIFF
--- a/recipe/job.yaml
+++ b/recipe/job.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccount: pangeo-forge
       containers:
         - name: flow
-          image: prefecthq/prefect:latest
+          image: pangeoforge/terraclimate
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "-c"]
           args:

--- a/recipe/pipeline.py
+++ b/recipe/pipeline.py
@@ -244,7 +244,7 @@ class TerraclimatePipeline(AbstractPipeline):
             prefect_directory="/home/jovyan/prefect",
             python_dependencies=[
                 "git+https://github.com/pangeo-forge/pangeo-forge@master",
-                "prefect==0.13.4",
+                "prefect==0.13.6",
             ],
             image_tag="latest",
         )

--- a/recipe/pipeline.py
+++ b/recipe/pipeline.py
@@ -259,12 +259,11 @@ class TerraclimatePipeline(AbstractPipeline):
             raise ValueError("Zarr target requires self.targets be a length one list")
 
         with Flow(self.name, storage=self.storage, environment=self.environment) as _flow:
-
             # download to cache
-            nc_sources = [download(k, self.cache_location) for k in self.sources]
+            nc_sources = download.map(self.sources, cache_location=self.cache_location)
 
             # convert cached netcdf data to zarr
-            cached_sources = [nc2zarr(k, self.cache_location) for k in nc_sources]
+            cached_sources = nc2zarr.map(nc_sources, cache_location=self.cache_location)
 
             # combine all datasets into a single zarr archive
             combine_and_write(cached_sources, target)

--- a/recipe/worker_pod.yaml
+++ b/recipe/worker_pod.yaml
@@ -7,7 +7,7 @@ spec:
   serviceAccountName: pangeo-forge
   serviceAccount: pangeo-forge
   containers:
-  - image: prefecthq/prefect:latest
+  - image: pangeoforge/terraclimate
     imagePullPolicy: IfNotPresent
     args: [dask-worker, --no-bokeh, --death-timeout, '60']
     name: dask-worker


### PR DESCRIPTION
The flow runs were timing out (during scheduling?) in part because we had ~1,000+ tasks. This switches to Task.map, which generates them on the fly.

I need to fixup the permission issue on the the bucket, then we should be good.